### PR TITLE
Fix bug in signal handler on Windows

### DIFF
--- a/tgeraser/core.py
+++ b/tgeraser/core.py
@@ -52,8 +52,11 @@ async def main() -> None:
     """
     Entry function
     """
-    loop = asyncio.get_running_loop()
-    loop.add_signal_handler(signal.SIGINT, signal_handler)
+    try:
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGINT, signal_handler)
+    except NotImplementedError:
+        pass
 
     arguments = docopt(__doc__, version=VERSION)
     limit = cast_to_int(arguments["--limit"], "limit") if arguments["--limit"] else None


### PR DESCRIPTION
Windows doesn't support signals in Python. Rather than check for the OS version using the platform library, simply graceful proceed if an exception is raised here.