### PR TITLE
optional proxy argument bug fixed

### DIFF
--- a/tgeraser/core.py
+++ b/tgeraser/core.py
@@ -93,7 +93,7 @@ async def main() -> None:
             "older_than": older_than,
             "delete_conversation": arguments["--delete-conversation"],
             "media_types": arguments["--media-type"],
-            "proxy": _parse_proxy(arguments["--proxy"]),
+            "proxy": _parse_proxy(arguments.get("--proxy")),
         }
         await run_eraser(kwargs)
     except ValueError as err:


### PR DESCRIPTION
Desc:

If the optional `--proxy` arg is not provided, `tgeraser` fails:

```
 File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\site-packages\tgeraser\core.py", line 96, in main
    "proxy": _parse_proxy(arguments["--proxy"]),
                          ~~~~~~~~~^^^^^^^^^^^
KeyError: '--proxy'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Scripts\tgeraser.exe\__main__.py", line 5, in <module>
    sys.exit(entry())
             ~~~~~^^
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\site-packages\tgeraser\core.py", line 123, in entry
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\asyncio\runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\asyncio\runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\asyncio\base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "C:\Users\{username}\anaconda3\envs\fresh_python\Lib\site-packages\tgeraser\core.py", line 104, in main
    raise TgEraserException(f"An unexpected error occurred: {err}") from err
tgeraser.exceptions.TgEraserException: An unexpected error occurred: '--proxy' 
```

If the argument is provided, the new session dialog is not available.

optional proxy argument bug fixed